### PR TITLE
add musl-libc for static link musl-libc as its small footprint

### DIFF
--- a/Dockerfile_builder
+++ b/Dockerfile_builder
@@ -70,6 +70,7 @@ RUN set -x; echo "Starting image build for Debian Stretch" \
         lzma-dev                                       \
         openssl                                        \
         mingw-w64                                      \
+        musl-tools                                     \
         libssl-dev                                  && \
 				apt -y autoremove && \
     		apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*


### PR DESCRIPTION
When compile _CGO_ program, the program may be run in [Alpine](https://alpinelinux.org/) based container which used `musl-libc` instead of `glibc`, we can static linking `musl-libc` then the program doesn't depend on `libc`.