### PR TITLE
feat: update Go to 1.16.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross
 
 COPY entrypoint.sh /
 
-ARG GO_VERSION=1.16.6
-ARG GOLANG_DIST_SHA=be333ef18b3016e9d7cb7b1ff1fdb0cac800ca0be4cf2290fe613b3d069dfe0d
+ARG GO_VERSION=1.16.7
+ARG GOLANG_DIST_SHA=7fe7a73f55ba3e2285da36f8b085e5c0159e9564ef5f63ee0ed6b818ade8ef04
 
 # update golang
 RUN \

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # golang parameters
-ARG GO_VERSION=1.16.6
+ARG GO_VERSION=1.16.7
 
 # osxcross parameters
 ARG OSX_VERSION_MIN=10.12


### PR DESCRIPTION
This PR updates Go to the latest 1.16 available which is 1.16.7


Maybe can we have a `golang-cross-builder` release as well? 