### PR TITLE
add docker cli to support docker push support of GoReleaser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,17 @@ RUN \
 	git-chglog -v && \
 	chmod +x /entrypoint.sh
 
+# install Docker CLI
+ARG DOCKER_CLI_VERSION=20.10.8
+ARG DOCKER_CLI_SHA=7ea11ecb100fdc085dbfd9ab1ff380e7f99733c890ed815510a5952e5d6dd7e0
+RUN  \
+    DOCKER_CLI_DOWNLOAD_FILE=docker-${DOCKER_CLI_VERSION}.tgz && \
+    curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_CLI_VERSION}.tgz && \
+    echo "$DOCKER_CLI_SHA $DOCKER_CLI_DOWNLOAD_FILE" | sha256sum -c - || exit 1 && \
+    tar xzvf docker-${DOCKER_CLI_VERSION}.tgz --strip 1 -C /usr/local/bin docker/docker && \
+    rm docker-${DOCKER_CLI_VERSION}.tgz && \
+    docker -v
+
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 
 # CMD ["goreleaser", "-v"]


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

```shell
      docker container run --rm --privileged \
      -v $(pwd):/kink \
      -v /var/run/docker.sock:/var/run/docker.sock \
      -w /kink \
      --entrypoint="/bin/sh" \
      -e GITLAB_TOKEN=$GITLAB_TOKEN \
      ghcr.io/gythialy/golang-cross:v1.16.6@sha256:a31f3981571aab561bfdc2c50bf25142f2460a47c35e76ae9d50826e3a1aabac \
      -c "GITLAB_TOKEN=$GITLAB_TOKEN make release"
```
When I tried the command above I got an error while pushing my docker images defined in the `dockers` section within the `.goreleaer.yml` file, the error was saying `docker executable not found in $PATH` because the `ghcr.io/gythialy/golang-cross` image has not `Docker CLI` installed in it, so this PR is going to add `Docker CLI` to the image.

