### PR TITLE
add buildx support for GoReleaser

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,17 @@ RUN  \
     rm docker-${DOCKER_CLI_VERSION}.tgz && \
     docker -v
 
+# install Buildx
+ARG BUILDX_VERSION=0.6.2
+ARG BUILDX_SHA=c2b374eb2f9cb71d6968059623d4ec3b53aa5873fce24595ff23c061c21d5384
+RUN \
+    BUILDX_DOWNLOAD_FILE=buildx-v${BUILDX_VERSION}.linux-amd64 && \
+    wget https://github.com/docker/buildx/releases/download/v${BUILDX_VERSION}/buildx-v${BUILDX_VERSION}.linux-amd64 && \
+    echo "${BUILDX_SHA} ${BUILDX_DOWNLOAD_FILE}" | sha256sum -c - || exit 1 && \
+    chmod a+x buildx-v${BUILDX_VERSION}.linux-amd64 && \
+    mkdir -p ~/.docker/cli-plugins && \
+    mv buildx-v${BUILDX_VERSION}.linux-amd64 ~/.docker/cli-plugins/docker-buildx
+
 ENTRYPOINT ["bash", "/entrypoint.sh"]
 
 # CMD ["goreleaser", "-v"]


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

We need this because GoReleaser has 3 engines (Docker, Buildx, and Podman(GoReleaser pro only)) to support for building&pushing images, this PR aims to add the Buildx engine support.

> https://goreleaser.com/customization/docker/#customization

<img width="1525" alt="Screen Shot 2021-08-27 at 12 24 19" src="https://user-images.githubusercontent.com/16693043/131105447-89f08684-ccac-4699-82ef-830872996485.png">

cc: @cpanato 