### PR TITLE
Update builder to use go 1.18

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write
       contents: read
     env:
-      GOLANG_CROSS_TAG: "v1.17.8-1"
+      GOLANG_CROSS_TAG: "v1.18.0-0"
       DOCKER_REGISTRY: "ghcr.io"
 
     steps:

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -41,5 +41,4 @@ jobs:
       shell: bash
       env:
         COSIGN_EXPERIMENTAL: 1
-        COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         DOCKER_PASSWD: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -41,5 +41,4 @@ jobs:
       shell: bash
       env:
         COSIGN_EXPERIMENTAL: 1
-        COSIGN_PASSWORD: ${{secrets.COSIGN_PASSWORD}}
         DOCKER_PASSWD: ${{ secrets.DEPLOY_TOKEN }}

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # golang parameters
-ARG GO_VERSION=1.17.8
+ARG GO_VERSION=1.18
 
 # osxcross parameters
 ARG OSX_VERSION_MIN=10.12


### PR DESCRIPTION
- remove secret that is not used anymore
- Update builder to use go 1.18