### PR TITLE
update builder to use go 1.17.9 in the go-1.17 branch

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write
       contents: read
     env:
-      GOLANG_CROSS_TAG: "v1.17.8-0"
+      GOLANG_CROSS_TAG: "v1.17.9-0"
 
     steps:
     - uses: actions/checkout@v2

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # golang parameters
-ARG GO_VERSION=1.17.8
+ARG GO_VERSION=1.17.9
 
 # osxcross parameters
 ARG OSX_VERSION_MIN=10.12


### PR DESCRIPTION
- update builder to use go 1.17.9 in the go-1.17 branch

after this merges will release the builder 1.17.9-0 and then open a pr to build the go cross image for go 1.17