### PR TITLE
update builder to use go 1.18.1

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -11,7 +11,7 @@ jobs:
       packages: write
       contents: read
     env:
-      GOLANG_CROSS_TAG: "v1.18.0-0"
+      GOLANG_CROSS_TAG: "v1.18.1-0"
       DOCKER_REGISTRY: "ghcr.io"
 
     steps:

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,5 +1,5 @@
 # golang parameters
-ARG GO_VERSION=1.18
+ARG GO_VERSION=1.18.1
 
 # osxcross parameters
 ARG OSX_VERSION_MIN=10.12


### PR DESCRIPTION
- update builder to use go 1.18.1

after this merges will release the builder 1.18.1-0 and then open a pr to build the go cross image for go 1.18