### PR TITLE
update action and cosign image

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@v2.0.1
+    - uses: sigstore/cosign-installer@v2.3.0
 
     - name: Get Repo Owner
       id: get_repo_owner

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@v2.0.1
+    - uses: sigstore/cosign-installer@v2.3.0
 
     - name: Get Repo Owner
       id: get_repo_owner

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross
 COPY entrypoint.sh /
 
 # install cosign
-COPY --from=gcr.io/projectsigstore/cosign:v1.7.2@sha256:ad2985a87622d5934a4bc06a61faadff772e377937e42519af4f506e1b019d1e /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c /ko-app/cosign /usr/local/bin/cosign
 # install syft
 COPY --from=docker.io/anchore/syft:v0.44.0@sha256:91ba44e1f5704cbb3c7c2917f458acfbb8971c014f5c2ee102f3f3314a5bcee5 /syft /usr/local/bin/syft
 


### PR DESCRIPTION
update action and cosign image to use release 1.8.0 on the go-1.17 branch
