### PR TITLE
use the latest cross builder image for go1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross-builder:v1.17.10-0
+FROM ghcr.io/gythialy/golang-cross-builder:v1.17.11-0
 
 LABEL maintainer="Goren G<gythialy.koo+github@gmail.com>"
 LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross


### PR DESCRIPTION
- use the latest cross builder image for go1.17