### PR TITLE
use the latest cross builder image for go1.18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross-builder:v1.18.2-0
+FROM ghcr.io/gythialy/golang-cross-builder:v1.18.3-0
 
 LABEL maintainer="Goren G<gythialy.koo+github@gmail.com>"
 LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross


### PR DESCRIPTION
- use the latest cross builder image for go1.18