### PR TITLE
update cosign to use release v1.9.0

### DIFF
--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@v2.3.0
+    - uses: sigstore/cosign-installer@v2.4.0
 
     - name: Get Repo Owner
       id: get_repo_owner

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: sigstore/cosign-installer@v2.3.0
+    - uses: sigstore/cosign-installer@v2.4.0
 
     - name: Get Repo Owner
       id: get_repo_owner

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross
 COPY entrypoint.sh /
 
 # install cosign
-COPY --from=gcr.io/projectsigstore/cosign:v1.8.0@sha256:12b4d428529654c95a7550a936cbb5c6fe93a046ea7454676cb6fb0ce566d78c /ko-app/cosign /usr/local/bin/cosign
+COPY --from=gcr.io/projectsigstore/cosign:v1.9.0@sha256:ef2d14e16dbb7786d8713e4898a8512e69ace4105f5b371a9c115ffcc3e85d84 /ko-app/cosign /usr/local/bin/cosign
 # install syft
 COPY --from=docker.io/anchore/syft:v0.45.1@sha256:ca78c06aaee7ee3d62179d42ea061b428a8851c26eb52eb7e5c18af2df267053 /syft /usr/local/bin/syft
 


### PR DESCRIPTION
update cosign to use release v1.9.0 on branch `go-1.17`