### PR TITLE
update cross-builder to use base builder with go1.18.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross-builder:v1.18.4-0
+FROM ghcr.io/gythialy/golang-cross-builder:v1.18.5-0
 
 LABEL maintainer="Goren G<gythialy.koo+github@gmail.com>"
 LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross


### PR DESCRIPTION
update cross-builder to use base builder with go1.18.5


after this we can release it :)