### PR TITLE
update base image for golang builder go1.19

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross-builder:v1.18.5-0
+FROM ghcr.io/gythialy/golang-cross-builder:v1.19.0-0
 
 LABEL maintainer="Goren G<gythialy.koo+github@gmail.com>"
 LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross


### PR DESCRIPTION
update base image for golang builder go1.19


will cut a release after this get merged