### PR TITLE
feat: enable workflow inputs for building builder image

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,10 +8,10 @@ updates:
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
     # default location of `.github/workflows`
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: sigstore/cosign-installer@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Get Repo Owner
       id: get_repo_owner
       run: echo "repo_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
@@ -56,6 +58,8 @@ jobs:
           OSX_CROSS_COMMIT=${{ github.event.inputs.osxcross-git-hash || '50e86ebca7d14372febd0af8cd098705049161b9' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Sign the images
       run: |
         echo "sign ${{ steps.buildpush.outputs.digest }}"

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,6 +2,15 @@ name: Build golang-cross-builder
 
 on:
   workflow_dispatch:
+    inputs:
+      builder-tag:
+        description: golang cross builder tag name, with default value `v1.20.0-0`
+      golang-version:
+        description: golang version, with default value `v1.20`
+      osxcross-git-hash:
+        description: git commit hash of osx-cross project, with default value `50e86ebca7d14372febd0af8cd098705049161b9`
+      osx-min-version:
+        description: minimal macOS SDK deployment target, with default value `10.12`
 
 jobs:
   build:
@@ -11,7 +20,7 @@ jobs:
       packages: write
       contents: read
     env:
-      GOLANG_CROSS_TAG: "v1.20.0-0"
+      GOLANG_CROSS_TAG: ${{ github.event.inputs.builder-tag || 'v1.20.0-0' }}
       DOCKER_REGISTRY: "ghcr.io"
 
     steps:
@@ -41,6 +50,10 @@ jobs:
         context: .
         file: Dockerfile.builder
         push: ${{ github.event_name != 'pull_request' }}
+        build-args: |
+          GO_VERSION=${{ github.event.inputs.golang-version || '1.20' }}
+          OSX_VERSION_MIN=${{ github.event.inputs.osx-min-version || '10.12' }}
+          OSX_CROSS_COMMIT=${{ github.event.inputs.osxcross-git-hash || '50e86ebca7d14372febd0af8cd098705049161b9' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
     - name: Sign the images

--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -18,6 +18,8 @@ jobs:
     - name: Get Repo Owner
       id: get_repo_owner
       run: echo "repo_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Login to GitHub Container Registry
       if: github.event_name != 'pull_request'
       uses: docker/login-action@v2
@@ -30,5 +32,7 @@ jobs:
       with:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/golang-cross:latest
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: test example
       run: cd example && make snapshot

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: sigstore/cosign-installer@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v2
     - name: Get Repo Owner
       id: get_repo_owner
       run: echo "repo_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
@@ -44,6 +46,8 @@ jobs:
         push: ${{ github.event_name != 'pull_request' }}
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
     - name: Sign the images
       run: |
         echo "sign ${{ steps.buildpush.outputs.digest }}"

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -85,6 +85,7 @@ RUN \
   UNATTENDED=yes OSX_VERSION_MIN=${OSX_VERSION_MIN:-10.12} ./build.sh \
   && ./build_compiler_rt.sh \
   && rm -rf *~ build *.tar.xz \
-  && rm -rf ./.git
+  && rm -rf ./.git && \
+  ls -al "${OSX_CROSS_PATH}/target/bin"
 
 ENV PATH=${OSX_CROSS_PATH}/target/bin:$PATH

--- a/example/go.mod
+++ b/example/go.mod
@@ -1,5 +1,5 @@
 module github.com/gythialy/golang-cross-example
 
-go 1.18
+go 1.20
 
-require github.com/mattn/go-sqlite3 v1.14.7
+require github.com/mattn/go-sqlite3 v1.14.16

--- a/example/go.sum
+++ b/example/go.sum
@@ -1,2 +1,2 @@
-github.com/mattn/go-sqlite3 v1.14.7 h1:fxWBnXkxfM6sRiuH3bqJ4CfzZojMOLVc0UTsTglEghA=
-github.com/mattn/go-sqlite3 v1.14.7/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=


### PR DESCRIPTION
- enable workflow inputs for build builder image
  ```yaml
  inputs:
      builder-tag:
        description: golang cross builder tag name, with default value `v1.20.0-0`
      golang-version:
        description: golang version, with default value `v1.20`
      osxcross-git-hash:
        description: git commit hash of osx-cross project, with default value `50e86ebca7d14372febd0af8cd098705049161b9`
      osx-min-version:
        description: minimal macOS SDK deployment target, with default value `10.12`
  ```
- upgrade example mod
- enable docker build cache