### PR TITLE
update base image to use go1.20.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/gythialy/golang-cross-builder:v1.20.0-0
+FROM ghcr.io/gythialy/golang-cross-builder:v1.20.1-0
 
 LABEL maintainer="Goren G<gythialy.koo+github@gmail.com>"
 LABEL org.opencontainers.image.source https://github.com/gythialy/golang-cross


### PR DESCRIPTION
- update base image to use go1.20.1

after we merge this will run a new release