### PR TITLE
refactor: disable schedule task

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -2,8 +2,8 @@ name: Update depdencies
 
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "13 16 * * *"
+  # schedule:
+  #   - cron: "13 16 * * *"
 
 jobs:
   check-update:


### PR DESCRIPTION
We can manually execute this task before releasing a new version.