### PR TITLE
fix: skip first-interaction for bot accounts

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -23,6 +23,7 @@ jobs:
 
     steps:
       - name: First interaction
+        if: ${{ !endsWith(github.actor, '[bot]') }}
         uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3.1.0
         with:
           issue_message: |


### PR DESCRIPTION
## Problem

`actions/first-interaction` fires on every Dependabot PR, treating `dependabot[bot]` as a first-time contributor each time.

## Fix

Added an `if` condition to skip the step for all bot accounts:

```yaml
if: \${{ !endsWith(github.actor, '[bot]') }}
```

This filters out `dependabot[bot]`, `github-actions[bot]`, and any other bot accounts, so the welcome message only goes to real human first-time contributors.