### PR TITLE
fix: drop non-existent replace() expression in osx-sdk.yaml

### DIFF
--- a/.github/workflows/osx-sdk.yaml
+++ b/.github/workflows/osx-sdk.yaml
@@ -85,6 +85,18 @@ jobs:
         id: get_repo_owner
         run: echo "repo_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
+      - name: Compute image tag
+        id: compute_tag
+        shell: bash
+        env:
+          OS_LABEL: ${{ matrix.os }}
+        run: |
+          # Strip the optional -large suffix from the runner label for the
+          # image tag (macos-14-large -> macos-14). GitHub Actions expressions
+          # have no replace() function, so do it in shell.
+          tag="${OS_LABEL%-large}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
@@ -92,7 +104,7 @@ jobs:
           images: ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/osx-sdk
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
-            type=raw,value=${{ replace(matrix.os, '-large', '') }}
+            type=raw,value=${{ steps.compute_tag.outputs.tag }}
 
       - name: Login to GitHub Container Registry
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
## Problem

The `Pack OSX SDK` workflow fails to parse on GitHub Actions:

```
Invalid workflow file: .github/workflows/osx-sdk.yaml#L1
(Line: 93, Col: 17): Unrecognized function: 'replace'.
```

`replace()` is not a GitHub Actions expression function — the supported set is only `contains` / `startsWith` / `endsWith` / `format` / `join` / `toJSON` / `fromJSON` / `hashFiles`. The `replace(matrix.os, '-large', '')` tag expression therefore makes the whole workflow invalid, so it never runs (both the monthly cron and `workflow_dispatch` are dead).

## Fix

Compute the image tag in a shell step and reference its output instead of using an expression function that doesn't exist:

- New `Compute image tag` step strips the optional `-large` suffix via `${OS_LABEL%-large}` and writes it to `GITHUB_OUTPUT`.
- `docker/metadata-action` tag changed from `replace(matrix.os, '-large', '')` to `${{ steps.compute_tag.outputs.tag }}`.

Behavior is unchanged: `macos-14-large` → `macos-14`, `macos-15-large` → `macos-15`, plain labels pass through untouched.
