### PR TITLE
fix: grant build-builder job permissions in release workflow

### DIFF
--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -14,7 +14,10 @@ on:
     types:
       - created
 
-permissions: {}
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   resolve:


### PR DESCRIPTION
## Problem

The `release golang-cross` workflow fails at parse time (startup_failure) whenever it runs.

The workflow's top-level `permissions: {}` denies everything. Its `build-builder` job calls the reusable workflow `builder.yml` via `uses:`, and GitHub inherits the reusable workflow's `GITHUB_TOKEN` permissions from the **top level of the calling workflow** (job-level permissions do not propagate to a called workflow). So the nested `build-tools` / `build` jobs in `builder.yml`, which request `contents: read`, `packages: write`, `id-token: write`, end up with nothing allowed → the whole workflow is rejected:

```
Invalid workflow file: .github/workflows/release-golang-cross.yml#L96
... The nested job 'build-tools' is requesting 'contents: read, packages: write,
id-token: write', but is only allowed 'contents: none, packages: none, id-token: none'.
```

## Fix

Grant the three scopes the called workflow's jobs need at the **top level** of `release-golang-cross.yml` instead of `permissions: {}`:

```yaml
permissions:
  contents: read
  packages: write
  id-token: write
```

These are exactly the scopes the `release` job already declares at the job level, so nothing is newly exposed beyond what the workflow already uses to build, push and cosign-sign images.
