### PR TITLE
fix: grant build-builder permissions in auto-release workflow

### DIFF
--- a/.github/workflows/auto-release-go.yml
+++ b/.github/workflows/auto-release-go.yml
@@ -12,7 +12,10 @@ on:
         type: boolean
         default: false
 
-permissions: {}
+permissions:
+  contents: read
+  packages: write
+  id-token: write
 
 jobs:
   detect-and-update:


### PR DESCRIPTION
## Problem

The `🤖 Auto Release on Go Update` workflow fails at parse time (startup_failure) on every schedule run (run 32455129662).

Same root cause as the release-workflow fix in #455, but in the other file that calls the reusable workflow: the top-level `permissions: {}` on `auto-release-go.yml` is inherited by `builder.yml` (called via `uses:`), since job-level permissions do not propagate to a called reusable workflow. So the nested `build-tools` / `build` jobs — which request `contents: read`, `packages: write`, `id-token: write` — end up with nothing allowed, and the whole workflow is rejected:

```
Invalid workflow file: .github/workflows/auto-release-go.yml#L173
... The nested job 'build-tools' is requesting 'contents: read, packages: write,
id-token: write', but is only allowed 'contents: none, packages: none, id-token: none'.
```

## Fix

Grant the three scopes at the **top level** instead of `permissions: {}`:

```yaml
permissions:
  contents: read
  packages: write
  id-token: write
```

The `detect-and-update` and `create-pr` jobs keep their own job-level permissions (`contents: write` and `contents: write` + `pull-requests: write`), which override the top level — no scope is reduced. This matches the #455 fix for `release-golang-cross.yml`.
