### PR TITLE
fix: show all bumped majors in auto-release title and auto-add new major

### DIFF
--- a/.github/workflows/auto-release-go.yml
+++ b/.github/workflows/auto-release-go.yml
@@ -245,6 +245,21 @@ jobs:
             done
           fi
 
+          # Comma-separated list of every bumped version (bare, e.g.
+          # "1.25.14, 1.26.7") for the PR title + summary, so a multi-major
+          # update is visible instead of only the highest one.
+          BUMPED_VERSIONS=""
+          if [ -n "$UPDATED_MAJORS" ]; then
+            for m in $(echo "$UPDATED_MAJORS" | tr ',' ' '); do
+              v=$(jq -r --arg m "$m" '.releases[$m].version // empty' versions.json)
+              if [ -n "$v" ] && [ "$v" != "null" ]; then
+                BUMPED_VERSIONS="${BUMPED_VERSIONS}, ${v#go}"
+              fi
+            done
+            BUMPED_VERSIONS="${BUMPED_VERSIONS#, }"
+          fi
+          [ -z "$BUMPED_VERSIONS" ] && BUMPED_VERSIONS="${GO_VER}"
+
           # Write PR body to temp file with printf/echo — NOT a heredoc: under
           # YAML block-scalar indentation the heredoc terminator carries leading
           # spaces, which neither << nor <<- can match, so the heredoc silently
@@ -253,7 +268,7 @@ jobs:
             {
               echo "## What's Changed"
               echo
-              echo "Bump Go to **${GO_VER}** and update tool dependencies."
+              echo "Bump Go to **${BUMPED_VERSIONS}** and update tool dependencies."
               echo
               echo "### Builder images"
               printf '%s\n' "${BUILDER_IMAGES}"
@@ -265,7 +280,7 @@ jobs:
               echo "1. Review and merge this PR"
               echo "2. Run the [release workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/release-golang-cross.yml) (workflow_dispatch); it reads this list and builds all pending versions"
             } > /tmp/pr-body.md
-            TITLE="🤖 bump go to ${GO_VER} and tools"
+            TITLE="🤖 bump go to ${BUMPED_VERSIONS} and tools"
           else
             {
               echo "## What's Changed"

--- a/scripts/check-update.sh
+++ b/scripts/check-update.sh
@@ -86,6 +86,21 @@ update_golang() {
     return 0
   fi
 
+  # Discover a newly released Go major (e.g. 1.27 became stable) that is not
+  # yet in .supported, and append it so the loop below creates its releases
+  # entry (via sync_versions_json) and bumps the tools Dockerfile to it. The
+  # newest stable version's major is always the highest supported after this.
+  local newest_stable newest_major
+  newest_stable=$(jq -r 'first(.[] | select(.stable == true) | .version)' "${golang_version_file}")
+  newest_major="${newest_stable%.*}"
+  newest_major="${newest_major#go}"
+  if [[ -n "${newest_major}" && "${newest_major}" != "null" ]] && ! jq -e --arg m "${newest_major}" '.supported | index($m)' "${VERSIONS_JSON}" >/dev/null 2>&1; then
+    jq --arg m "${newest_major}" '.supported += [$m]' "${VERSIONS_JSON}" >"${TMP_DIR}/versions.json.tmp" || return 1
+    mv "${TMP_DIR}/versions.json.tmp" "${VERSIONS_JSON}" || return 1
+    supported="${supported} ${newest_major}"
+    echo "new go major ${newest_major} discovered (${newest_stable}), added to supported"
+  fi
+
   GO_CHANGED=false
   latest_major=""
   UPDATED_MAJORS=""

--- a/versions.json
+++ b/versions.json
@@ -30,8 +30,6 @@
       ]
     },
     "1.26": {
-      "version": "go1.26.6",
-      "sha256": "708effb774be8237570d0add163225abbdfaf4fca28b2611df167beba4feef89",
       "version": "go1.26.7",
       "sha256": "ffb5f8de10c62550dfddab66b36b57030721e0a44a3218e9e1181d7b59f121ca",
       "codenames": [


### PR DESCRIPTION
## Problem

PR #460 (auto-release) only surfaced the 1.25 bump — its title was "bump go to 1.25.14", and its Pending releases listed only 1.25 — even though 1.26 also moved to go1.26.7. Merging it would build no 1.26 image.

Root cause: `versions.json`'s `1.26` entry had duplicate `version`/`sha256` keys (a manual-edit artifact from #457 — `go1.26.6` then `go1.26.7`). jq resolves duplicate keys to the last value, so `check-update.sh` read `cur_version = go1.26.7` (already new) and judged 1.26 "up to date", dropping it from `UPDATED_MAJORS`.

Separately, a newly released major (1.27 became stable) was never auto-added to `supported` — `update_golang` only iterated the majors already listed.

## Changes

1. **versions.json** — remove the duplicate keys; `1.26` now has a single `go1.26.7` / sha256 pair.
2. **check-update.sh** — `update_golang` discovers a newly released stable major not yet in `supported` and appends it (idempotent), so the existing loop creates its `releases` entry and bumps the tools Dockerfile.
3. **auto-release-go.yml** — build a comma-separated `BUMPED_VERSIONS` from `UPDATED_MAJORS` and use it in the PR title + body, so a multi-major update reads `bump go to 1.25.14, 1.26.7 and tools` instead of only the highest version.

## Verification

- `bash -n` + YAML parse + all 5 `run:` blocks pass.
- Logic simulated: `go1.27.0` → major `1.27` → appended to `supported` (idempotent on re-run); `UPDATED_MAJORS=1.25,1.26` → title `bump go to 1.25.14, 1.26.7 and tools`.
