### PR TITLE
fix: checkout the auto-release branch in create-pr

### DIFF
--- a/.github/workflows/auto-release-go.yml
+++ b/.github/workflows/auto-release-go.yml
@@ -202,6 +202,11 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          # Checkout the auto-release branch, not the trigger ref (main on
+          # schedule): the Pending releases list must read the branch's synced
+          # versions.json, not main's possibly-older copy (else a newly added
+          # major shows as "null" and bumped patches show stale versions).
+          ref: ${{ needs.detect-and-update.outputs.branch_name }}
           fetch-tags: true
           persist-credentials: false
 


### PR DESCRIPTION
## Problem

The Pending releases list in auto-release PR #464 shows stale versions (`1.25 (go1.25.13)`, `1.26 (go1.26.4)`) and `1.27 (null)`, even though the head branch's `versions.json` correctly contains go1.25.14 / go1.26.7 / go1.27.0.

Cause: the `create-pr` job's checkout had no `ref`, so on a schedule run it checked out **main** and read main's `versions.json` instead of the auto-release branch's synced copy. #463 had reverted main's 1.26 entry to go1.26.4 and dropped the 1.27 entry — hence the stale versions and the `null`.

Note: this does NOT break the actual release build — `release-golang-cross.yml` extracts only the majors from the Pending list (`grep '^- ' | awk '{print $2}'`) and looks up `versions.json` on merged main, which has the correct entries. It is a display/review-integrity bug: the reviewer cannot trust the version numbers in the PR body.

## Fix

Checkout the auto-release branch in `create-pr`:

```yaml
ref: ${{ needs.detect-and-update.outputs.branch_name }}
```

(`build-builder` already passed the same ref; only `create-pr` missed it.)

## Verification

- YAML parse OK; the change is limited to the `create-pr` job's checkout step.
