### PR TITLE
fix: coerce reusable-workflow booleans and extract indented pending items

### DIFF
--- a/.github/workflows/auto-release-go.yml
+++ b/.github/workflows/auto-release-go.yml
@@ -186,7 +186,10 @@ jobs:
       ref: ${{ needs.detect-and-update.outputs.branch_name }}
       version: ${{ needs.detect-and-update.outputs.updated_majors }}
       latest_major: ${{ needs.detect-and-update.outputs.latest_major }}
-      publish_latest: ${{ needs.detect-and-update.outputs.publish_latest }}
+      # job outputs are STRINGS ('true'/'false'); reusable-workflow boolean
+      # inputs require a real boolean and reject the string form with
+      # "Unexpected value 'true'" at parse time — compare to coerce.
+      publish_latest: ${{ needs.detect-and-update.outputs.publish_latest == 'true' }}
       push_images: false
 
   create-pr:
@@ -220,31 +223,26 @@ jobs:
           BRANCH="${{ needs.detect-and-update.outputs.branch_name }}"
           TOOLS_ONLY="${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}"
 
-          # Pending releases: the majors that moved in this PR, consumed by
-          # release-golang-cross.yml to build those versions' images.
-          # tools-only rebuilds builders but does not change golang versions,
-          # so no Pending releases (nothing for the release workflow to build).
+          # NOTE: list items are built with printf so they start at column 0
+          # ("- 1.x (...)"): the release workflow extracts them with grep '^- ',
+          # and embedding them in the quoted string would inherit this script's
+          # YAML indentation (which broke extraction for PR #466).
           PENDING=""
           BUILDER_IMAGES=""
           if [ "$TOOLS_ONLY" != "true" ] && [ -n "$UPDATED_MAJORS" ]; then
             for m in $(echo "$UPDATED_MAJORS" | tr ',' ' '); do
               v=$(jq -r --arg m "$m" '.releases[$m].version' versions.json)
               vb="${v#go}"
-              PENDING="${PENDING}
-            - $m ($v)"
+              PENDING="${PENDING}$(printf '\n- %s (%s)' "$m" "$v")"
               # A major may list multiple builders (1.24 = osxcross + zig); emit
               # one image line per builder so the release PR body stays accurate.
               # zig majors publish the self-contained golang-cross image with a
               # -zig suffix; osxcross majors publish the golang-cross-builder base.
               for b in $(jq -r --arg m "$m" '.releases[$m].builders[]' versions.json); do
                 if [ "$b" = "zig" ]; then
-                  BUILDER_IMAGES="${BUILDER_IMAGES}
-            - \`ghcr.io/gythialy/golang-cross:v${vb}-0-bookworm-zig\`
-            - \`ghcr.io/gythialy/golang-cross:v${vb}-0-trixie-zig\`"
+                  BUILDER_IMAGES="${BUILDER_IMAGES}$(printf '\n- `ghcr.io/gythialy/golang-cross:v%s-0-bookworm-zig`\n- `ghcr.io/gythialy/golang-cross:v%s-0-trixie-zig`' "$vb" "$vb")"
                 else
-                  BUILDER_IMAGES="${BUILDER_IMAGES}
-            - \`ghcr.io/gythialy/golang-cross-builder:v${vb}-0-bookworm\`
-            - \`ghcr.io/gythialy/golang-cross-builder:v${vb}-0-trixie\`"
+                  BUILDER_IMAGES="${BUILDER_IMAGES}$(printf '\n- `ghcr.io/gythialy/golang-cross-builder:v%s-0-bookworm`\n- `ghcr.io/gythialy/golang-cross-builder:v%s-0-trixie`' "$vb" "$vb")"
                 fi
               done
             done

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -56,7 +56,7 @@ jobs:
               echo "PR #${PR}"
               VERSIONS=$(gh pr view "$PR" --json body --jq '.body' \
                 | sed -n '/## Pending releases/,/^## /p' \
-                | grep '^- ' | awk '{print $2}' | paste -sd, -)
+                | grep '^[[:space:]]*-' | awk '{print $2}' | paste -sd, -)
             fi
           fi
 


### PR DESCRIPTION
## Problem

Two failures in the multi-version release path:

1. **Scheduled auto-release fails at parse time** (run 32817788635):
   `Unexpected value 'true'` at `auto-release-go.yml` line 189. The job output
   `publish_latest` is a STRING ('true'/'false'), but `builder.yml` declares the
   reusable-workflow input as `type: boolean`. GitHub requires a real boolean
   there and rejects the string form. It surfaced only after #461 made the
   output always non-empty.

2. **Merged auto-release PR builds no images** (#466, run 32820162086: resolve
   ok, build-builder + release skipped). The Pending releases list items were
   written with the step's YAML indentation (`  - 1.25 (go1.25.14)`), but the
   release workflow extracts majors with a line-start anchor `grep '^- '` —
   which matched nothing, so `VERSIONS` was empty and the push-trigger run took
   the skip branch.

## Fix

- `auto-release-go.yml`: coerce with `publish_latest: ${{ ...outputs.publish_latest == 'true' }}`
  (comparison yields a real boolean), and build both list blocks with `printf`
  so items start at column 0.
- `release-golang-cross.yml`: make extraction whitespace-tolerant
  (`grep '^[[:space:]]*-'`) so already-merged PR bodies (e.g. #466) still
  resolve — re-running release for 1.25,1.26,1.27 works without editing the PR.

## Verification

- act (local): on rolled-back main, `detect-and-update` correctly detected all
  three majors (`updated_majors=1.25,1.26,1.27`, new-major discovery of 1.27,
  `publish_latest=true`, `branch_name=auto-release/go-1.27.0`). Test branch and
  bot commit cleaned up afterwards.
- create-pr body generation simulated with stubbed `gh`: Pending releases and
  Builder images now render at column 0; title reads
  "bump go to 1.25.14, 1.26.7, 1.27.0".
- Extraction closed loop: old pipeline against #466's body reproduces the bug
  (empty); the fixed pipeline returns `1.25,1.26,1.27`, which feeds the release
  matrix jq into the expected 6 zig targets (bookworm/trixie x 3 versions).
