### PR TITLE
fix: make publish decisions input-driven and fail loud on release drift

### DIFF
--- a/.github/workflows/auto-release-go.yml
+++ b/.github/workflows/auto-release-go.yml
@@ -44,13 +44,15 @@ jobs:
 
       - name: Run check-update.sh
         id: check
+        env:
+          TOOLS_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}
         run: |
-          EXTRA=""
-          if [ "${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}" = "true" ]; then
-            EXTRA="--tools-only"
+          if [ "$TOOLS_ONLY" = "true" ]; then
             echo "manual tools-only update"
+            bash scripts/check-update.sh --tools-only | tee /tmp/check-update.log
+          else
+            bash scripts/check-update.sh | tee /tmp/check-update.log
           fi
-          bash scripts/check-update.sh $EXTRA | tee /tmp/check-update.log
           # consume machine-readable versions block printed by the script
           VERSIONS=$(sed -n '/^##VERSIONS##$/,$p' /tmp/check-update.log)
           GO_VERSION=$(echo "$VERSIONS" | grep '^GO_VERSION=' | cut -d= -f2)
@@ -61,21 +63,20 @@ jobs:
 
       - name: Compare and prepare
         id: parse
+        env:
+          TOOLS_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}
         run: |
-          # no file changes means nothing to update
-          if git diff --quiet -- Dockerfile Dockerfile.builder Dockerfile.zig versions.json; then
+          # Dockerfile.tools carries tool bumps and is committed below,
+          # so the skip check must watch it too.
+          if git diff --quiet -- Dockerfile Dockerfile.tools Dockerfile.builder Dockerfile.zig versions.json; then
             echo "skip=true" >> "$GITHUB_OUTPUT"
             echo "No changes — nothing to do"
             exit 0
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
-          TOOLS_ONLY="${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}"
-
-          # Any supported major that moved (from check-update.sh) counts as a
-          # golang update; tools are only updated together with golang, so there
-          # is no tools-only branch — except manual tools_only dispatch, which
-          # rebuilds every supported major's builder with the new tool versions.
+          # Any moved major counts as a golang update; tools ride along.
+          # Manual tools-only dispatch rebuilds every supported major instead.
           UPDATED_MAJORS="${{ steps.check.outputs.updated_majors }}"
           if [ "$TOOLS_ONLY" = "true" ]; then
             UPDATED_MAJORS=$(jq -r '.supported | join(",")' versions.json)
@@ -117,8 +118,7 @@ jobs:
           echo "major_minor=${HIGHEST_UPDATED}" >> "$GITHUB_OUTPUT"
           echo "builder_tag=v${UPDATED_VERSION#go}-0" >> "$GITHUB_OUTPUT"
 
-          # latest tag only when the newest supported major is among the
-          # updated ones (read from versions.json supported list)
+          # latest only when the highest supported major is among the updated
           HIGHEST=$(jq -r '.supported[-1]' versions.json)
           echo "latest_major=${HIGHEST}" >> "$GITHUB_OUTPUT"
           LATEST_VERSION=$(jq -r --arg m "$HIGHEST" '.releases[$m].version // empty' versions.json)
@@ -133,13 +133,10 @@ jobs:
       - name: Sync builder/zig GO_VERSION and builder tag
         if: steps.parse.outputs.skip == 'false' && steps.parse.outputs.go_changed == 'true'
         run: |
-          # check-update.sh already wrote the newest supported major's bare
-          # version (e.g. 1.26) into Dockerfile.tools. The builder (osxcross)
-          # tracks its own baseline (1.24), while the zig image tracks the
-          # newest major — they must NOT be synced to the same value.
+          # Dockerfile.tools carries the newest supported major; the zig
+          # image tracks it, while osxcross keeps its own older baseline.
           GO_VER=$(grep '^ARG GO_VERSION=' Dockerfile.tools | sed 's/ARG GO_VERSION=//')
 
-          # Dockerfile.zig (zig image) -> newest major
           if [ -f Dockerfile.zig ]; then
             CURRENT_ZIG_GO=$(grep '^ARG GO_VERSION=' Dockerfile.zig | sed 's/ARG GO_VERSION=//')
             if [ "$CURRENT_ZIG_GO" != "$GO_VER" ]; then
@@ -147,9 +144,8 @@ jobs:
             fi
           fi
 
-          # Dockerfile.builder (osxcross) + main Dockerfile BUILDER_TAG ->
-          # the osxcross baseline version, not the newest major (1.26 is zig
-          # and has no golang-cross-builder image).
+          # builder image + main-image BUILDER_TAG follow the osxcross
+          # baseline, NOT the newest major.
           OSXCROSS_VER=$(jq -r '[.releases | to_entries[] | select(.value.builders | index("osxcross")) | .value.version] | sort | last' versions.json)
           OSXCROSS_BARE="${OSXCROSS_VER#go}"
           if [ -n "$OSXCROSS_VER" ] && [ "$OSXCROSS_VER" != "null" ]; then
@@ -162,16 +158,17 @@ jobs:
 
       - name: Commit and push to branch
         if: steps.parse.outputs.skip == 'false'
+        env:
+          REMOTE_URL: https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          # versions.json is synced by check-update.sh; include it in the bump commit.
-          # Tools only update together with golang, so there is no tools-only commit.
+          # versions.json is synced by check-update.sh — include it.
           git add Dockerfile Dockerfile.tools Dockerfile.builder Dockerfile.zig versions.json
           git commit -m "🤖 bump go to ${{ steps.parse.outputs.go_version }} and tools"
 
           BRANCH="${{ steps.parse.outputs.branch_name }}"
-          git push -f "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" "HEAD:${BRANCH}"
+          git push -f "$REMOTE_URL" "HEAD:${BRANCH}"
 
   build-builder:
     needs: detect-and-update
@@ -186,15 +183,17 @@ jobs:
       ref: ${{ needs.detect-and-update.outputs.branch_name }}
       version: ${{ needs.detect-and-update.outputs.updated_majors }}
       latest_major: ${{ needs.detect-and-update.outputs.latest_major }}
-      # job outputs are STRINGS ('true'/'false'); reusable-workflow boolean
-      # inputs require a real boolean and reject the string form with
-      # "Unexpected value 'true'" at parse time — compare to coerce.
+      # job output strings must be coerced ('== true'), or the reusable
+      # workflow rejects them with "Unexpected value 'true'" at parse time.
       publish_latest: ${{ needs.detect-and-update.outputs.publish_latest == 'true' }}
       push_images: false
 
   create-pr:
     needs: [detect-and-update, build-builder]
-    if: always() && needs.detect-and-update.result == 'success' && needs.detect-and-update.outputs.skip == 'false' && (needs.detect-and-update.outputs.go_changed == 'true' || needs.detect-and-update.outputs.branch_name == 'auto-release/tools' || needs.build-builder.result == 'success')
+    # The PR is the human-review gate for images that already built and
+    # smoke-tested cleanly — a red build-builder means nothing to review,
+    # so no PR opens (no always(): default skip-on-failure is wanted here).
+    if: needs.detect-and-update.result == 'success' && needs.build-builder.result == 'success' && needs.detect-and-update.outputs.skip == 'false'
 
     runs-on: ubuntu-latest
 
@@ -217,16 +216,14 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           UPDATED_MAJORS: ${{ needs.detect-and-update.outputs.updated_majors }}
+          TOOLS_ONLY: ${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}
         run: |
           GO_VER="${{ needs.detect-and-update.outputs.go_version }}"
           GO_CHANGED="${{ needs.detect-and-update.outputs.go_changed }}"
           BRANCH="${{ needs.detect-and-update.outputs.branch_name }}"
-          TOOLS_ONLY="${{ github.event_name == 'workflow_dispatch' && inputs.tools_only == true }}"
 
-          # NOTE: list items are built with printf so they start at column 0
-          # ("- 1.x (...)"): the release workflow extracts them with grep '^- ',
-          # and embedding them in the quoted string would inherit this script's
-          # YAML indentation (which broke extraction for PR #466).
+          # List items start at column 0: release-golang-cross.yml extracts
+          # them with grep '^- ' (indented items broke extraction, #466).
           PENDING=""
           BUILDER_IMAGES=""
           if [ "$TOOLS_ONLY" != "true" ] && [ -n "$UPDATED_MAJORS" ]; then
@@ -263,10 +260,7 @@ jobs:
           fi
           [ -z "$BUMPED_VERSIONS" ] && BUMPED_VERSIONS="${GO_VER}"
 
-          # Write PR body to temp file with printf/echo — NOT a heredoc: under
-          # YAML block-scalar indentation the heredoc terminator carries leading
-          # spaces, which neither << nor <<- can match, so the heredoc silently
-          # swallowed the rest of the script (title + gh pr create never ran).
+          # Body via grouped redirect — heredocs break under YAML indentation.
           if [ "$GO_CHANGED" = "true" ]; then
             {
               echo "## What's Changed"
@@ -281,7 +275,7 @@ jobs:
               echo
               echo "### How to release"
               echo "1. Review and merge this PR"
-              echo "2. Run the [release workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/release-golang-cross.yml) (workflow_dispatch); it reads this list and builds all pending versions"
+              echo "2. Run the [release workflow](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/release-golang-cross.yml); it reads this list and builds all pending versions"
             } > /tmp/pr-body.md
             TITLE="🤖 bump go to ${BUMPED_VERSIONS} and tools"
           else
@@ -292,7 +286,7 @@ jobs:
               echo
               echo "### How to release"
               echo "1. Review and merge this PR"
-              echo "2. Run the [release workflow](${{ github.server_url }}/${{ github.repository }}/actions/workflows/release-golang-cross.yml) (workflow_dispatch) to publish the main \`golang-cross\` Docker image"
+              echo "2. Run the [release workflow](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/workflows/release-golang-cross.yml) to publish the main \`golang-cross\` Docker image"
             } > /tmp/pr-body.md
             TITLE="🤖 update tool dependencies"
           fi

--- a/.github/workflows/builder.yml
+++ b/.github/workflows/builder.yml
@@ -2,18 +2,17 @@ name: Build golang-cross-builder
 
 on:
   workflow_dispatch:
-  workflow_call:
     inputs:
       ref:
-        description: Git ref to build from (branch/tag/sha). Defaults to the triggering ref.
+        description: Git ref to build from (branch/tag/sha). Defaults to the default branch.
         type: string
         required: false
       publish_latest:
-        description: Whether to also tag the newest major's build as `latest` (defaults to true for manual dispatch, false when called from auto-release). The latest tag points at the highest supported major's trixie image (currently 1.26 zig).
+        description: Also tag the newest major's build as `latest` (default true).
         type: boolean
         required: false
       version:
-        description: Only build this Go major.minor (e.g. 1.26). Empty builds all supported versions from versions.json.
+        description: Only build these Go major.minor versions (comma-separated, e.g. 1.26 or 1.25,1.26). Empty builds all supported versions.
         type: string
         required: false
       latest_major:
@@ -21,7 +20,29 @@ on:
         type: string
         required: false
       push_images:
-        description: Push built images to the registry (false = build locally for smoke-test only). Defaults to true for manual dispatch, false when called from auto-release PR verification.
+        description: Push built images to the registry (default true; false = build locally for smoke-test only).
+        type: boolean
+        required: false
+  workflow_call:
+    inputs:
+      ref:
+        description: Git ref to build from (branch/tag/sha). Defaults to the triggering ref.
+        type: string
+        required: false
+      publish_latest:
+        description: Also tag the newest major's trixie build as `latest` (default true).
+        type: boolean
+        required: false
+      version:
+        description: Only build these Go major.minor versions (comma-separated, e.g. 1.26 or 1.25,1.26). Empty builds all supported versions.
+        type: string
+        required: false
+      latest_major:
+        description: Major.minor that owns the latest tag (defaults to the highest supported). Ignored when publish_latest is false.
+        type: string
+        required: false
+      push_images:
+        description: Push built images to the registry (default true; false = build locally for smoke-test only).
         type: boolean
         required: false
 
@@ -42,13 +63,9 @@ jobs:
       - name: Build matrix from versions.json
         id: set-matrix
         run: |
-          # versions.json: each supported version x codename x builder.
-          # A version may list multiple builders (1.24 ships both osxcross and
-          # zig); matrix expands the product, matrix_tools dedupes to
-          # version x codename for the shared tools image.
-          # When version input is set (auto-release), only build those versions'
-          # builder images (comma-separated list allowed, e.g. 1.24,1.25);
-          # manual dispatch builds the full matrix.
+          # Each version x codename x builder; the comma-separated version
+          # input scopes the build, matrix_tools dedupes to version x codename
+          # for the shared tools image.
           if [ -n "${{ inputs.version }}" ]; then
             MATRIX=$(jq -c --arg v "${{ inputs.version }}" '[.releases | to_entries[] | .key as $m | select(($v | split(",")) | index($m)) | .value as $v2 | $v2.codenames[] as $c | $v2.builders[] as $b | {gover: $m, go_version: $v2.version, codename: $c, builder: $b}]' versions.json)
           else
@@ -142,13 +159,18 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Sign the images
+        # Always pushed above, so a missing digest means an action regression.
         run: |
-          echo "sign ${STEPS_BUILDPUSH_OUTPUTS_DIGEST}"
-          cosign sign --yes "ghcr.io/${STEPS_GET_REPO_OWNER_OUTPUTS_REPO_OWNER}/golang-cross-tools@${STEPS_BUILDPUSH_OUTPUTS_DIGEST}"
+          if [ -z "$DIGEST" ]; then
+            echo "push=true but the build-push step produced no digest; refusing to sign an empty reference" >&2
+            exit 1
+          fi
+          echo "signing ghcr.io/${REPO_OWNER}/golang-cross-tools@${DIGEST}"
+          cosign sign --yes "ghcr.io/${REPO_OWNER}/golang-cross-tools@${DIGEST}"
         shell: bash
         env:
-          STEPS_BUILDPUSH_OUTPUTS_DIGEST: ${{ steps.buildpush.outputs.digest }}
-          STEPS_GET_REPO_OWNER_OUTPUTS_REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
+          DIGEST: ${{ steps.buildpush.outputs.digest }}
+          REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
 
   build:
     needs: [load-versions, build-tools]
@@ -184,12 +206,14 @@ jobs:
 
       - name: Select Dockerfile by builder
         id: dockerfile
+        env:
+          BUILDER: ${{ matrix.builder }}
         run: |
           # strip leading "go" from version for golang official image tags
           GO_BARE="${{ matrix.go_version }}"
           GO_BARE="${GO_BARE#go}"
           echo "go_bare=${GO_BARE}" >> "$GITHUB_OUTPUT"
-          if [ "${{ matrix.builder }}" = "zig" ]; then
+          if [ "$BUILDER" = "zig" ]; then
             echo "file=Dockerfile.zig" >> "$GITHUB_OUTPUT"
             # zig builds publish to the main golang-cross repo, tag suffixed with -zig
             echo "image=golang-cross" >> "$GITHUB_OUTPUT"
@@ -206,7 +230,7 @@ jobs:
         with:
           images: ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/${{ steps.dockerfile.outputs.image }}
           tags: |
-            type=raw,value=latest,enable=${{ (inputs.publish_latest == true || github.event_name == 'workflow_dispatch') && matrix.gover == needs.load-versions.outputs.latest_major && matrix.codename == 'trixie' }}
+            type=raw,value=latest,enable=${{ inputs.publish_latest != false && matrix.gover == needs.load-versions.outputs.latest_major && matrix.codename == 'trixie' }}
             type=raw,value=v${{ steps.dockerfile.outputs.go_bare }}-0-${{ matrix.codename }}${{ steps.dockerfile.outputs.tag_suffix }}
             type=raw,value=${{ matrix.gover }}${{ steps.dockerfile.outputs.tag_suffix }}
 
@@ -223,13 +247,14 @@ jobs:
         with:
           context: .
           file: ${{ steps.dockerfile.outputs.file }}
-          # push_images=false (PR smoke-test) still needs the image in the
-          # local daemon for docker run; push=true implies load via registry
+          # Push depends ONLY on this boolean input (default true).
+          # github.event_name inside a reusable workflow is the CALLER's
+          # trigger — conditioning on it silently disabled pushing when the
+          # release ran on push events (empty-digest cosign failure).
           load: ${{ inputs.push_images == false }}
-          push: ${{ github.event_name == 'workflow_dispatch' && inputs.push_images != false || github.event_name == 'workflow_call' && inputs.push_images == true }}
-          # zig is verified multi-arch (amd64+arm64); osxcross stays amd64-only
-          # until its cross toolchain is verified on arm64 hosts. PR smoke-test
-          # (push_images=false) loads a single amd64 image into the local daemon.
+          push: ${{ inputs.push_images != false }}
+          # zig ships multi-arch; osxcross stays amd64-only. Local builds
+          # (push_images=false) load a single amd64 image for docker run.
           platforms: ${{ matrix.builder == 'zig' && inputs.push_images != false && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
           build-args: |
             GO_VERSION=${{ steps.dockerfile.outputs.go_bare }}
@@ -247,18 +272,23 @@ jobs:
             ${{ matrix.builder == 'osxcross' && format('type=registry,ref=ghcr.io/{0}/golang-cross:buildcache-osxcross-{1},mode=max', steps.get_repo_owner.outputs.repo_owner, matrix.codename) || 'type=gha,mode=max' }}
 
       - name: Sign the images
+        # Nothing is published when building locally for the PR smoke-test.
+        if: inputs.push_images != false
         run: |
-          echo "sign ${STEPS_BUILDPUSH_OUTPUTS_DIGEST}"
-          cosign sign --yes "ghcr.io/${STEPS_GET_REPO_OWNER_OUTPUTS_REPO_OWNER}/${{ steps.dockerfile.outputs.image }}@${STEPS_BUILDPUSH_OUTPUTS_DIGEST}"
+          if [ -z "$DIGEST" ]; then
+            echo "push=true but the build-push step produced no digest; refusing to sign an empty reference" >&2
+            exit 1
+          fi
+          echo "signing ghcr.io/${REPO_OWNER}/${IMAGE_NAME}@${DIGEST}"
+          cosign sign --yes "ghcr.io/${REPO_OWNER}/${IMAGE_NAME}@${DIGEST}"
         shell: bash
         env:
-          STEPS_BUILDPUSH_OUTPUTS_DIGEST: ${{ steps.buildpush.outputs.digest }}
-          STEPS_GET_REPO_OWNER_OUTPUTS_REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
+          DIGEST: ${{ steps.buildpush.outputs.digest }}
+          REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
+          IMAGE_NAME: ${{ steps.dockerfile.outputs.image }}
 
-      # PR-stage zig smoke test. The zig image is self-contained (FROM the
-      # tools base), so it is built here and smoke-tested in the SAME job —
-      # the image was --load'ed into the local daemon and docker run sees it.
-      # (A separate job cannot pull it: nothing is pushed in PR mode.)
+      # PR-stage zig smoke test runs HERE: the image was --load'ed into this
+      # job's daemon and nothing was pushed, so no other job can pull it.
       - name: Smoke-test zig image (PR verification)
         if: matrix.builder == 'zig' && inputs.push_images == false && matrix.codename == 'trixie'
         run: |

--- a/.github/workflows/os-compat-check.yml
+++ b/.github/workflows/os-compat-check.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Run OS compat check
         id: check
         continue-on-error: true
+        # tee keeps the log for the issue body below.
         run: |
           bash scripts/check-os-compat.sh --verbose 2>&1 | tee /tmp/compat.log
 
@@ -28,25 +29,27 @@ jobs:
         if: steps.check.outcome == 'failure'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SERVER_URL: ${{ github.server_url }}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
         run: |
-          cat > /tmp/compat-log-body.md <<'ISSUE_EOF'
-          ## OS compatibility drift detected
-
-          The `versions.json` matrix references golang official image tags that no longer exist on Docker Hub (or new combinations are available). This breaks the builder matrix.
-
-          Details from the check:
-
-          ```
-          ISSUE_EOF
-          cat /tmp/compat.log >> /tmp/compat-log-body.md
-          cat >> /tmp/compat-log-body.md <<'ISSUE_EOF'
-          ```
-
-          ### How to fix
-          Update `codenames` in `versions.json` for the affected Go versions, then run the `builder.yml` workflow to rebuild.
-          ISSUE_EOF
+          {
+            echo "## OS compatibility drift detected"
+            echo
+            echo 'The `versions.json` matrix references golang official image tags that no longer exist on Docker Hub (or new combinations are available). This breaks the builder matrix.'
+            echo
+            echo "Details from the check:"
+            echo
+            echo '```'
+            cat /tmp/compat.log
+            echo '```'
+            echo
+            echo "### How to fix"
+            echo 'Update `codenames` in `versions.json` for the affected Go versions, then run the `builder.yml` workflow to rebuild.'
+            echo
+            echo "[Workflow run](${SERVER_URL}/${REPOSITORY}/actions/runs/${RUN_ID})"
+          } > /tmp/compat-log-body.md
           gh issue create \
             --title "🤖 OS compatibility drift in versions.json" \
             --body-file /tmp/compat-log-body.md \
             --assignee gythialy 2>&1 || true
-          exit 0

--- a/.github/workflows/osx-sdk.yaml
+++ b/.github/workflows/osx-sdk.yaml
@@ -144,7 +144,6 @@ jobs:
             type=raw,value=${{ steps.compute_tag.outputs.tag }}
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ${{ env.DOCKER_REGISTRY }}
@@ -158,7 +157,7 @@ jobs:
           file: Dockerfile.osx_sdk
           build-args: |
             SDK_FILE=${{ steps.args.outputs.sdk_file }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -35,14 +35,14 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSIONS: ${{ inputs.versions }}
         run: |
-          # 1) explicit input wins (manual dispatch)
-          # 2) release tag -> that single major (backward compat)
-          # 3) push to main -> read Pending releases from the latest merged
-          #    auto-release PR body (skip when there is none)
-          VERSIONS="${{ inputs.versions }}"
+          # Priority: dispatch input > release tag > Pending releases in the
+          # latest merged auto-release PR body (push events skip when none).
+          VERSIONS="$INPUT_VERSIONS"
 
-          if [ -z "$VERSIONS" ] && [ "${{ github.event_name }}" = "release" ]; then
+          if [ -z "$VERSIONS" ] && [ "$EVENT_NAME" = "release" ]; then
             MAJOR_MINOR="${GITHUB_REF_NAME#v}"; MAJOR_MINOR="${MAJOR_MINOR%.*}"
             echo "Release tag: ${GITHUB_REF_NAME} (major.minor: ${MAJOR_MINOR})"
             VERSIONS="$MAJOR_MINOR"
@@ -60,9 +60,14 @@ jobs:
             fi
           fi
 
+          # Tolerate whitespace in the dispatch input ("1.24, 1.25"): the
+          # matrix jq splits on bare commas, so a stray space would leave a
+          # valid major silently unmatched.
+          VERSIONS="${VERSIONS// /}"
+
           echo "Versions to release: ${VERSIONS:-<none>}"
           if [ -z "$VERSIONS" ]; then
-            if [ "${{ github.event_name }}" = "push" ]; then
+            if [ "$EVENT_NAME" = "push" ]; then
               echo "No Pending releases in the latest merged auto-release PR; nothing to do"
               echo "skip=true" >> "$GITHUB_OUTPUT"
             else
@@ -72,6 +77,18 @@ jobs:
             exit 0
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"
+
+          # Fail loudly when a requested major has no versions.json entry.
+          # The matrix jq silently drops unknown majors, so a stale Pending
+          # list (or a typo in the dispatch input) would otherwise skip that
+          # version's images forever while the workflow stays green.
+          MISSING=$(echo "$VERSIONS" | tr ',' '\n' | while read -r m; do
+            jq -e --arg m "$m" '.releases[$m]' versions.json >/dev/null 2>&1 || echo "$m"
+          done)
+          if [ -n "$MISSING" ]; then
+            echo "No versions.json entry for requested release(s): $(echo "$MISSING" | paste -sd, -)"
+            exit 1
+          fi
 
           MATRIX=$(jq -c --arg v "$VERSIONS" \
             '[.releases | to_entries[]
@@ -84,6 +101,8 @@ jobs:
                  builder: $b, codename: $c}]' versions.json)
 
           if [[ "$MATRIX" == "[]" || -z "$MATRIX" ]]; then
+            # Defensive: the per-major check above should make this
+            # unreachable, but never build an empty matrix.
             echo "No version entries in versions.json for: ${VERSIONS}"
             exit 1
           fi
@@ -99,8 +118,8 @@ jobs:
   build-builder:
     needs: resolve
     if: needs.resolve.outputs.skip != 'true'
-    # PR stage did not push builder images; publish them now so the main
-    # image build below can FROM golang-cross-builder:<tag>
+    # Publish the builder images the PR stage built locally: the main-image
+    # FROM below needs them in the registry.
     uses: ./.github/workflows/builder.yml
     with:
       ref: main
@@ -111,9 +130,8 @@ jobs:
 
   release:
     needs: [resolve, build-builder]
-    # Only the osxcross main image needs a build here; zig is self-contained
-    # and already built + tagged by builder.yml's build job. Skip entirely
-    # when no osxcross version is in this release (e.g. a zig-only release).
+    # Only the osxcross main image builds here (zig is self-contained and
+    # already published by builder.yml); skip when this release has none.
     if: needs.resolve.outputs.skip != 'true' && needs.resolve.outputs.matrix_osxcross != '[]'
     strategy:
       matrix:
@@ -145,8 +163,7 @@ jobs:
           GO_VERSION="${{ matrix.version }}"
           echo "go_version_bare=${GO_VERSION#go}" >> "$GITHUB_OUTPUT"
           echo "builder_tag=v${GO_VERSION#go}-0" >> "$GITHUB_OUTPUT"
-          # This job only builds the osxcross main image (zig is excluded from
-          # the matrix), so the Dockerfile is fixed.
+          # Only the osxcross main image builds here, so the Dockerfile is fixed.
           echo "dockerfile=Dockerfile" >> "$GITHUB_OUTPUT"
 
       - name: Docker meta
@@ -159,7 +176,6 @@ jobs:
             type=raw,value=${{ matrix.major }}
 
       - name: Login to GitHub Container Registry
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
@@ -169,9 +185,8 @@ jobs:
       - name: Prepare build args
         id: args
         run: |
-          # Dockerfile.zig takes a bare GO_VERSION (no "go" prefix); the
-          # osxcross Dockerfile only takes BUILDER_TAG + OS_CODENAME (Go
-          # already comes from the golang-cross-builder base image).
+          # The osxcross Dockerfile takes BUILDER_TAG + OS_CODENAME only;
+          # Go comes preinstalled in the golang-cross-builder base image.
           echo "go_arg=${{ steps.params.outputs.go_version_bare }}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push
@@ -180,7 +195,7 @@ jobs:
         with:
           context: .
           file: ${{ steps.params.outputs.dockerfile }}
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           load: true
           build-args: |
             OS_CODENAME=${{ matrix.codename }}
@@ -193,11 +208,16 @@ jobs:
 
       - name: Sign the images
         run: |
-          echo "sign ${{ steps.buildpush.outputs.digest }}"
-          cosign sign --yes "ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/golang-cross@${{ steps.buildpush.outputs.digest }}"
+          if [ -z "$DIGEST" ]; then
+            echo "push=true but the build-push step produced no digest; refusing to sign an empty reference" >&2
+            exit 1
+          fi
+          echo "signing ghcr.io/${REPO_OWNER}/golang-cross@${DIGEST}"
+          cosign sign --yes "ghcr.io/${REPO_OWNER}/golang-cross@${DIGEST}"
         shell: bash
         env:
-          DOCKER_PASSWD: ${{ secrets.GITHUB_TOKEN }}
+          DIGEST: ${{ steps.buildpush.outputs.digest }}
+          REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
 
       # Smoke-test the published osxcross image against the sqlite example.
       # (zig is smoke-tested in builder.yml's build job during PR verification.)


### PR DESCRIPTION
## Root cause

Run [32823480550](https://github.com/gythialy/golang-cross/actions/runs/32823480550/job/97728884605) failed at signing:

```
Error: signing [ghcr.io/gythialy/golang-cross@]: parsing reference: could not parse reference
```

`builder.yml` conditioned `push:`/`load:` on `github.event_name`, but inside a reusable workflow invoked via `workflow_call` the event is the **caller's** trigger — `'workflow_call'` never appears as an event. #467 made the release pipeline run automatically on push events for the first time; both branches of the condition evaluated false, so images were built but never pushed, the build-push step produced no digest output, and cosign received an empty reference. Manual-dispatch releases masked this because branch 1 held there.

## What's changed

**Core fix — builder.yml**
- `push:` / `load:` / latest-tag now derive solely from boolean inputs using unset-as-default comparisons (`inputs.push_images != false`); no dependency on trigger event type
- `workflow_dispatch` gains mirrored inputs (`ref`, `version`, `latest_major`, `publish_latest`, `push_images`) so both entries share defaults

**Audit fixes found while re-checking every workflow**
- `release-golang-cross.yml`: requested majors are validated against `versions.json` before matrix generation — a stale Pending list or typo now fails loudly instead of silently skipping that version's images forever; versions input is whitespace-normalized; dead `pull_request` conditions removed
- `auto-release-go.yml`: skip check now watches `Dockerfile.tools` (tool bumps are written and committed there but were never checked — tools-only updates were silently dropped); `create-pr` requires `build-builder` success instead of `always()` so failed builds/smoke tests no longer open review PRs
- All three cosign sign steps unified: env-passed `DIGEST`/`REPO_OWNER`, empty-digest guard that exits 1 with a clear message, step-level condition matching the push state

**Conventions applied across all workflows**
- GHA expressions enter `run:` bodies only via step `env:` (never interpolated into `[ ]` tests or URLs)
- Booleans compare as strings at every boundary (`[ "$VAR" = "true" ]`, `outputs.x == 'true'`)
- No heredocs under YAML block scalars (`os-compat-check.yml` issue body now uses grouped redirects)
- Comments reduced to non-obvious why (traps, incident refs); stale hardcodes removed

## Verification

- YAML parse + `bash -n` on every `run:` script across all 8 workflows: clean
- Anti-pattern sweep (expression-in-test, heredocs, legacy env names): clean
- Resolve validation functionally tested against main's `versions.json`: `1.24,1.25` passes, `1.25,1.26,1.27` fails listing `1.27`, `"1.24, 1.25"` normalized and passes
- create-pr gate truth table: build failure/cancellation → no PR; success + skip=false → opens
- Caller compatibility: auto-release passes `push_images: false` (unchanged semantics); release passes `true` — pushing now works on **all** caller trigger types

## Release note

Merging this to main is itself a push event → the release workflow re-triggers and publishes the images that failed to push in run 32823480550 (Pending list: 1.25, 1.26, 1.27 from the latest merged auto-release PR). No manual dispatch needed.
