### PR TITLE
fix: skip push-triggered releases when every image is already published

### DIFF
--- a/.github/workflows/release-golang-cross.yml
+++ b/.github/workflows/release-golang-cross.yml
@@ -37,6 +37,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSIONS: ${{ inputs.versions }}
+          REPO_OWNER: ${{ github.repository_owner }}
         run: |
           # Priority: dispatch input > release tag > Pending releases in the
           # latest merged auto-release PR body (push events skip when none).
@@ -82,11 +83,12 @@ jobs:
           # The matrix jq silently drops unknown majors, so a stale Pending
           # list (or a typo in the dispatch input) would otherwise skip that
           # version's images forever while the workflow stays green.
-          MISSING=$(echo "$VERSIONS" | tr ',' '\n' | while read -r m; do
-            jq -e --arg m "$m" '.releases[$m]' versions.json >/dev/null 2>&1 || echo "$m"
-          done)
+          MISSING=""
+          for m in $(echo "$VERSIONS" | tr ',' '\n'); do
+            jq -e --arg m "$m" '.releases[$m]' versions.json >/dev/null 2>&1 || MISSING="${MISSING}${m},"
+          done
           if [ -n "$MISSING" ]; then
-            echo "No versions.json entry for requested release(s): $(echo "$MISSING" | paste -sd, -)"
+            echo "No versions.json entry for requested release(s): ${MISSING%,}"
             exit 1
           fi
 
@@ -113,6 +115,47 @@ jobs:
           echo "matrix_osxcross=${MATRIX_OSXCROSS}" >> "$GITHUB_OUTPUT"
           echo "versions=${VERSIONS}" >> "$GITHUB_OUTPUT"
           echo "latest_major=$(jq -r '.supported[-1]' versions.json)" >> "$GITHUB_OUTPUT"
+
+          # Push-triggered runs re-read the Pending list of the latest merged
+          # bot PR on EVERY push to main, and that list lives in a merged PR
+          # body forever — without this guard any later hotfix merge would
+          # rebuild everything it names. Skip only when every expected final
+          # tag already exists in ghcr (a partial release still reruns);
+          # explicit dispatch always rebuilds. A failed tag listing aborts
+          # instead of falling back to a blind full rebuild.
+          if [ "$EVENT_NAME" = "push" ]; then
+            chmod +x scripts/registry-tags.sh
+            fetch_tags() {
+              local out
+              out=$(bash scripts/registry-tags.sh "$REPO_OWNER" "$1") || {
+                echo "ghcr tag listing failed for $1; refusing to decide blindly" >&2
+                exit 1
+              }
+              printf '%s\n' "$out" | sort -u
+            }
+            TOOLS_TAGS=$(fetch_tags golang-cross-tools)
+            MAIN_ZIG_TAGS=$(fetch_tags golang-cross)
+            BUILDER_TAGS=$(fetch_tags golang-cross-builder)
+            MISSING=$(echo "$MATRIX" | jq -r '.[] | [.major, .version, .codename, .builder] | @tsv' |
+              while read -r major version codename builder; do
+                vb="${version#go}"
+                case "$builder" in
+                  zig)      want="v${vb}-0-${codename}-zig"; pool="$MAIN_ZIG_TAGS" ;;
+                  osxcross) want="v${vb}-0-${codename}";      pool="$BUILDER_TAGS" ;;
+                esac
+                grep -Fxq -- "$want" <<<"$pool" || echo "${major}: ${want}"
+                tools="v${vb}-0-${codename}"
+                grep -Fxq -- "$tools" <<<"$TOOLS_TAGS" || echo "${major}: golang-cross-tools:${tools}"
+              done)
+            if [ -z "$MISSING" ]; then
+              echo "All requested images already published; nothing to rebuild"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Missing images, rebuilding:"
+            echo "$MISSING"
+          fi
+
           echo "Matrix: ${MATRIX}"
 
   build-builder:
@@ -155,7 +198,9 @@ jobs:
 
       - name: Get Repo Owner
         id: get_repo_owner
-        run: echo "repo_owner=$(echo ${{ github.repository_owner }} | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+        env:
+          OWNER: ${{ github.repository_owner }}
+        run: echo "repo_owner=$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
 
       - name: Prepare version params
         id: params
@@ -223,8 +268,11 @@ jobs:
       # (zig is smoke-tested in builder.yml's build job during PR verification.)
       - name: Test sqlite-example (cgo cross-compile smoke)
         if: matrix.codename == 'trixie'
+        env:
+          GO_BARE: ${{ steps.params.outputs.go_version_bare }}
+          REPO_OWNER: ${{ steps.get_repo_owner.outputs.repo_owner }}
         run: |
           cd example/sqlite-example
-          IMAGE="ghcr.io/${{ steps.get_repo_owner.outputs.repo_owner }}/golang-cross:v${{ steps.params.outputs.go_version_bare }}-0-trixie"
+          IMAGE="ghcr.io/${REPO_OWNER}/golang-cross:v${GO_BARE}-0-trixie"
           echo "testing with ${IMAGE}"
           make smoke-test IMAGE="${IMAGE}" CONFIG=".goreleaser.yml"

--- a/scripts/registry-tags.sh
+++ b/scripts/registry-tags.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Print the tags that exist in ghcr for an image, one per line.
+# Usage: registry-tags.sh <owner> <image>
+#
+# Anonymous pull scope works for public packages; private ones return no
+# tags here (the caller treats "missing" as not-published, which is the
+# conservative direction for a skip guard).
+set -euo pipefail
+
+owner=${1:?usage: registry-tags.sh <owner> <image>}
+image=${2:?usage: registry-tags.sh <owner> <image>}
+# tr instead of ${var,,}: macOS ships bash 3.2 (no case-modifier expansion)
+owner=$(printf '%s' "$owner" | tr '[:upper:]' '[:lower:]')
+image=$(printf '%s' "$image" | tr '[:upper:]' '[:lower:]')
+
+# Retry transient blips (timeouts / 5xx / 429); persistent failures still
+# exit non-zero so the caller refuses to decide blindly.
+CURL="curl -fsSL --retry 3 --retry-delay 2"
+
+token=$($CURL "https://ghcr.io/token?scope=repository:${owner}/${image}:pull" |
+  sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+[ -n "$token" ] || { echo "no anonymous token for ${owner}/${image}" >&2; exit 1; }
+
+url="https://ghcr.io/v2/${owner}/${image}/tags/list?n=1000"
+while [ -n "$url" ]; do
+  resp=$($CURL -H "Authorization: Bearer $token" -D /tmp/.registry-headers "$url")
+  printf '%s' "$resp" | jq -r '.tags[]?'
+  url=$(sed -n 's/^[Ll]ink:.*<\([^>]*\)>.*/\1/p' /tmp/.registry-headers)
+done


### PR DESCRIPTION
## Problem

The Pending releases list lives in a merged PR body **forever**, and the release workflow re-reads it on **every push to main**. Any later hotfix merge therefore rebuilds and re-signs everything the latest auto-release PR ever named — run [32957201688](https://github.com/gythialy/golang-cross/actions/runs/32957201688) rebuilt all 1.25/1.26/1.27 tools + zig images purely because #470 (a commit-message fix) merged. Wasted runner time and pointless cache churn; correctness was unaffected.

## Fix

`resolve` now guards push-triggered runs: before building, it lists each image's tags from ghcr anonymously (new `scripts/registry-tags.sh`, Link-header pagination, curl `--retry 3` for transient blips) and checks every expected final tag:

| artifact | image | tag |
|---|---|---|
| zig | `golang-cross` | `v{ver}-0-{codename}-zig` |
| osxcross builder | `golang-cross-builder` | `v{ver}-0-{codename}` |
| tools (shared) | `golang-cross-tools` | `v{ver}-0-{codename}` |

- All present → `skip=true`, nothing rebuilt
- Anything missing → rebuild exactly as today (partial releases complete on rerun)
- Tag listing fails → abort loudly instead of a blind full rebuild
- Manual `workflow_dispatch` unaffected — explicit trigger always rebuilds

No caching across runs by design: freshness is the whole point of the guard, and a stale "exists" would wrongly skip a needed release.

## Verification

Against the real registry (bash 5):

- Current state, `VERSIONS=1.25,1.26,1.27` → `All requested images already published; nothing to rebuild` → skip
- Pool with `v1.27.0-0-{bookworm,trixie}-zig` removed → lists exactly those two as missing → rebuilds
- Stale Pending without versions.json entry → still fails loudly listing `1.27`

All workflow scripts pass YAML parse + bash 5 `-n`; the in-run reuse pattern (one listing per image, pooled for all matrix rows) keeps this at ~8 requests per run.
